### PR TITLE
Improve package.json scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,12 @@
 
 Another take on the CPU emulator, this time on typescript
 
-To use on a *NIX system: use regular scripts 
-To use on windows use: *:simple (without cool output & prestart build)
+## Scripts
+`npm run build` - Compiles the project's TypeScript into JavaScript 
+`npm run build:rom` -Compiles the project and generates a ROM file 
+`npm run build:ram` -Compiles the project and generates a RAM file 
+
+`npm run lint` - Lints the project's code
+`npm run lint:fix` - Tries to fix any problems found while linting
+
+`npm run test` - Lints the project's code

--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 Another take on the CPU emulator, this time on typescript
 
-To use on a *NIX system: use regular scripts
+To use on a *NIX system: use regular scripts 
 To use on windows use: *:simple (without cool output & prestart build)

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 Another take on the CPU emulator, this time on typescript
 
 ## Scripts
-`npm run build` - Compiles the project's TypeScript into JavaScript 
-`npm run build:rom` -Compiles the project and generates a ROM file 
-`npm run build:ram` -Compiles the project and generates a RAM file 
+`npm run build` - Compiles the project's TypeScript into JavaScript  
+`npm run build:rom` - Compiles the project and generates a ROM file  
+`npm run build:ram` - Compiles the project and generates a RAM file  
 
-`npm run lint` - Lints the project's code
-`npm run lint:fix` - Tries to fix any problems found while linting
+`npm run lint` - Lints the project's code  
+`npm run lint:fix` - Tries to fix any problems found while linting  
 
 `npm run test` - Lints the project's code

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,12 @@
         "color-convert": "^1.9.0"
       }
     },
+    "arg": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
+      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -294,6 +300,12 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "diff": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+      "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
@@ -997,6 +1009,12 @@
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
     },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -1543,6 +1561,19 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "ts-node": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.0.tgz",
+      "integrity": "sha512-fbG32iZEupNV2E2Fd2m2yt1TdAwR3GTCrJQBHDevIiEBNy1A8kqnyl1fv7jmRmmbtcapFab2glZXHJvfD1ed0Q==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^3.0.0"
+      }
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -1632,6 +1663,12 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,21 +4,14 @@
   "description": "A cpu emulator written in TS",
   "main": "dist/node.js",
   "scripts": {
-    "test": "echo null",
-    "start": "echo \"> Starting\" && node .",
+    "start": "node .",
     "prestart": "npm run build",
-    "build": "npm run lint; printf \"> Cleaning up\t\"; true || rm -rf dist/*; printf \"✅\n\"; printf \"> Building\t\"; tsc; printf \"✅\n\"",
-    "lint": "printf \"> Linting\t\"; eslint 'src/*'; printf \"✅\n\"",
-    "lint:fix": "printf \"> Linting & fixing\t\"; eslint 'src/*' --fix; printf \"✅\n\"",
-    "build:rom": "npm run build && echo \"> Starting rom creation tool\" && node dist/rom.js",
-    "build:ram": "npm run build && echo \"> Starting ram creation tool\" && node dist/ram.js",
-
-    "start:simple": "node .",
-    "build:simple": "tsc",
-    "build:ram:simple": "npm run build:simple && node dist/ram.js",
-    "build:rom:simple": "npm run build:simple && node dist/rom.js",
-    "lint:simple": "eslint 'src/*'",
-    "lint:fix:simple": "eslint 'src/*' --fix"
+    "build": "ts-node scripts/build.ts",
+    "build:rom": "npm run build && node dist/rom.js",
+    "build:ram": "npm run build && node dist/ram.js",
+    "lint": "ts-node scripts/lint.ts 'src/*'",
+    "lint:fix": "ts-node scripts/lint.ts --fix 'src/*'",
+    "test": "npm run build && npm run lint"
   },
   "keywords": [
     "cpu",
@@ -40,6 +33,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.1"
+    "eslint-plugin-standard": "^4.0.1",
+    "ts-node": "^8.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build:ram": "npm run build && node dist/ram.js",
     "lint": "ts-node scripts/lint.ts 'src/*'",
     "lint:fix": "ts-node scripts/lint.ts --fix 'src/*'",
-    "test": "npm run build && npm run lint"
+    "pretest": "npm run build",
+    "test": "npm run lint"
   },
   "keywords": [
     "cpu",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,32 @@
+import path from 'path'
+import { spawnSync } from 'child_process'
+import { Logger, deleteFolder, colors } from './utils'
+
+let exitCode = 0
+
+// Clean old 'dist folder'
+const cleanLogger = new Logger('Cleaning')
+
+try {
+	const deleted = deleteFolder(path.join(__dirname, '../dist/'))
+	cleanLogger.end(false, deleted ? "'dist' folder deleted successfully" : "'dist' folder not present")
+} catch (err) {
+	exitCode = 1
+	cleanLogger.end(true, `'dist' folder couldn't be deleted: ${colors.red(err.message)}`)
+}
+
+// Compile source
+const buildLogger = new Logger('Building')
+const tsc = spawnSync('npx', ['tsc'], { encoding: 'utf8' })
+
+const output = tsc.stdout.split('\n')
+
+if (tsc.status === 0) {
+	buildLogger.end(false, 'Build passed')
+} else {
+	exitCode = 1
+	buildLogger.end(true, 'Build failed')
+	output.forEach(out => buildLogger.info(colors.red(out), '  ↦ '))
+}
+
+process.exit(exitCode)

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -1,0 +1,20 @@
+import { spawnSync } from 'child_process'
+import { Logger, colors } from './utils'
+
+let exitCode = 0
+
+// Limt source code
+const buildLogger = new Logger('Linting')
+const eslint = spawnSync('npx', ['eslint', ...process.argv], { encoding: 'utf8' })
+
+const output = eslint.stdout.split('\n')
+
+if (eslint.status === 0) {
+	buildLogger.end(false, 'Linting passed\n')
+} else {
+	exitCode = 1
+	buildLogger.end(true, 'Linting failed')
+	output.forEach(out => buildLogger.info(colors.red(out), '  ↦ '))
+}
+
+process.exit(exitCode)

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,0 +1,52 @@
+import fs from 'fs'
+import path from 'path'
+
+export function isEmpty (str: string): boolean {
+	return /^(?:\x1b\[\d+m\s*)*$/.test(str) // Matches an empty string, including empty ANSI escape codes
+}
+
+export function deleteFolder (folder: string): boolean {
+	if (fs.existsSync(folder)) {
+		fs.readdirSync(folder).forEach(file => {
+			const curPath = path.join(folder, file)
+			if (fs.lstatSync(curPath).isDirectory()) {
+				deleteFolder(curPath)
+			} else {
+				fs.unlinkSync(curPath)
+			}
+		})
+		fs.rmdirSync(folder)
+		return true
+	} else return false
+}
+
+export const colors = {
+	red:    (text: string) => `\x1b[31m${text}\x1b[0m`,
+	green:  (text: string) => `\x1b[32m${text}\x1b[0m`,
+	yellow: (text: string) => `\x1b[33m${text}\x1b[0m`,
+	blue:   (text: string) => `\x1b[34m${text}\x1b[0m`,
+	purple: (text: string) => `\x1b[35m${text}\x1b[0m`,
+	cyan:   (text: string) => `\x1b[36m${text}\x1b[0m`,
+}
+
+export class Logger {
+	constructor(str: string) {
+		this.log(`\n> ${str}...`)
+	}
+
+	log (str: string) {
+		process.stdout.write(str)
+	}
+
+	info (str: string, arrow = '↳') {
+		if (!isEmpty(str)) console.log(`  ${arrow} ${str}`)
+		else console.log() // Just add newline without the arrow
+	}
+
+	end (error?: boolean, info?: string) {
+		process.stdout.moveCursor(-3, 0) // Move cursor 3px to the left
+		process.stdout.clearLine(1) // Clear everything in front of the cursor
+		this.log(error ? colors.red(' ✘\n') : colors.green(' ✔\n'))
+		if (info) this.info(info)
+	}
+}

--- a/src/cpu.ts
+++ b/src/cpu.ts
@@ -51,7 +51,6 @@ export class CPU {
 
 	private bus = new Bus()
 
-
 	constructor (ram: Buffer, rom: Buffer, io = new ConsoleIO(4)) {
 		this.ram = new Memory(15, ram) // 32kB - 0x0000 - 0x7FFF
 		this.rom = new CustomMemory(MINST_COUNTER_LENGTH + INST_LENGHT, MINST_LENGTH, rom)

--- a/src/node.ts
+++ b/src/node.ts
@@ -3,6 +3,8 @@ import 'source-map-support/register'
 import { CPU } from './cpu'
 import { readFileSync } from 'fs'
 
+console.log('\n> Starting...')
+
 let cpu = new CPU(readFileSync('data/ram.bin'), readFileSync('data/rom.bin'))
 
 cpu.run()

--- a/src/ram.ts
+++ b/src/ram.ts
@@ -4,7 +4,7 @@ import { Memory } from './components/memory'
 import { createBinFile } from './utils/bin'
 import { inst as i } from './@types/instructions'
 
-console.log('\n> Building ROM...')
+console.log('\n> Building RAM...')
 
 let ram = new Memory(15) // first bit to select ram or another thing
 for (let idx = 0x00; idx < 0x8000; idx++) { // Empty it

--- a/src/ram.ts
+++ b/src/ram.ts
@@ -4,6 +4,8 @@ import { Memory } from './components/memory'
 import { createBinFile } from './utils/bin'
 import { inst as i } from './@types/instructions'
 
+console.log('\n> Building ROM...')
+
 let ram = new Memory(15) // first bit to select ram or another thing
 for (let idx = 0x00; idx < 0x8000; idx++) { // Empty it
 	ram.set(idx, i.NOP.code)

--- a/src/rom.ts
+++ b/src/rom.ts
@@ -5,6 +5,8 @@ import { createBinFile } from './utils/bin'
 
 import { MINST_COUNTER_LENGTH, INST_LENGHT, MINST_LENGTH, Instructions, inst } from './@types/instructions' // eslint-disable-line import/no-duplicates
 
+console.log('\n> Building RAM...')
+
 function createROM (inst: Instructions): CustomMemory {
 	// Each ROM stores a byte for each address
 	let rom = new CustomMemory(MINST_COUNTER_LENGTH + INST_LENGHT, MINST_LENGTH)

--- a/src/rom.ts
+++ b/src/rom.ts
@@ -5,7 +5,7 @@ import { createBinFile } from './utils/bin'
 
 import { MINST_COUNTER_LENGTH, INST_LENGHT, MINST_LENGTH, Instructions, inst } from './@types/instructions' // eslint-disable-line import/no-duplicates
 
-console.log('\n> Building RAM...')
+console.log('\n> Building ROM...')
 
 function createROM (inst: Instructions): CustomMemory {
 	// Each ROM stores a byte for each address


### PR DESCRIPTION
This PR moves the app's scripts from the project's `package.json` into separate node scripts. This brings some significant advantages
 - The scripts now work on non-UNIX terminals (namely Windows' CMD)
 - They are now easier to debug and maintain since now they aren't bash one-liners
 - Now it looks better and has real output handling if part of the script returns an error


Demo screenshot:  
![image](https://user-images.githubusercontent.com/12110214/68778134-0a0dd980-0633-11ea-9076-8a7ea26e082e.png)



***Note:** the scripts are written in TypeScript to match this repo's language, but this means the `ts-node` package had to be added to be able to run them without previous compilation. However, if requested, they can be moved to normal JavaScript files to avoid the extra dependency.*